### PR TITLE
feat: add CockroachDB driver

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ Journey is based on the work of @mattes on his tool "migrate": https://github.co
  * [Cassandra](https://github.com/db-journey/cassandra-driver)
  * [SQLite](https://github.com/db-journey/sqlite3-driver)
  * [MySQL](https://github.com/db-journey/mysql-driver) ([experimental](https://github.com/mattes/migrate/issues/1#issuecomment-58728186))
+ * [CockroachDB](https://github.com/nexdrew/cockroachdb-driver)
  * Bash (planned)
 
 Need another driver? Just implement the [Driver interface](http://godoc.org/github.com/db-journey/migrate/driver#Driver) and open a PR.

--- a/main.go
+++ b/main.go
@@ -11,6 +11,7 @@ import (
 	_ "github.com/db-journey/mysql-driver"
 	_ "github.com/db-journey/postgresql-driver"
 	_ "github.com/db-journey/sqlite3-driver"
+	_ "github.com/nexdrew/cockroachdb-driver"
 	"github.com/urfave/cli"
 )
 


### PR DESCRIPTION
I still need to write automated tests and setup CI, but I'm at the end of my day and wanted to go ahead and throw this out there.

I have tested/verified manually on my local computer (Mac) by building `journey` with the new driver and running my own migration scripts against local db nodes.

A lot of the code is taken from either [twrobel3's CockroachDB driver for mattes/migrate](https://github.com/mattes/migrate/tree/master/database/cockroachdb) or from the [db-journey PostgreSQL driver](https://github.com/db-journey/postgresql-driver).

Let me know what you think.