### PR TITLE
Add SkipFlagParsing: true property to migrate sub command to fix negative relative migration

### DIFF
--- a/commands/migrate_commands.go
+++ b/commands/migrate_commands.go
@@ -153,11 +153,12 @@ var resetCommand = cli.Command{
 }
 
 var migrateCommand = cli.Command{
-	Name:      "migrate",
-	Aliases:   []string{"m"},
-	Usage:     "Apply migrations -n|+n",
-	ArgsUsage: "<n>",
-	Flags:     MigrateFlags,
+	Name:            "migrate",
+	Aliases:         []string{"m"},
+	Usage:           "Apply migrations -n|+n",
+	ArgsUsage:       "<n>",
+	Flags:           MigrateFlags,
+	SkipFlagParsing: true,
 	Action: func(ctx *cli.Context) error {
 		relativeN := ctx.Args().First()
 		relativeNInt, err := strconv.Atoi(relativeN)


### PR DESCRIPTION
Addresses #4 by adding `SkipFlagParsing: true` to the migrate subcommand. 🤞

Tested all migrate migrate scenarios (+n, -n, up, down) successfully.