### PR TITLE
v2

### DIFF
--- a/commands/commands.go
+++ b/commands/commands.go
@@ -1,6 +1,8 @@
 package journey
 
-import "github.com/urfave/cli"
+import (
+	"github.com/urfave/cli"
+)
 
 func Commands() cli.Commands {
 	return cli.Commands{


### PR DESCRIPTION
Compiles with https://github.com/db-journey/migrate/pull/3

# UPDATE
Now all original behavior is restored (including progress logging, ctrl-c to stop & repeat to force stop)
Also got rid of migrate "shortcut" functions.

## New features
- apply specific version (run up migration)
- rollback specific version (run down migration)


