### PR TITLE
Fix For GoTo CLI

### DIFF
--- a/commands/migrate_commands.go
+++ b/commands/migrate_commands.go
@@ -260,9 +260,7 @@ var gotoCommand = cli.Command{
 			logErr(err).Fatalf("failed to migrate to version %d", toVersionInt)
 		}
 
-		relativeNInt := toVersionInt - int(currentVersion)
-
-		err = migrate.Migrate(mctx, relativeNInt)
+		err = migrate.GoTo(mctx, int(currentVersion), toVersionInt)
 		if err != nil {
 			logErr(err).Fatalf("Failed to migrate to vefrsion %d", toVersionInt)
 		}

--- a/commands/migrate_commands.go
+++ b/commands/migrate_commands.go
@@ -260,7 +260,7 @@ var gotoCommand = cli.Command{
 			logErr(err).Fatalf("failed to migrate to version %d", toVersionInt)
 		}
 
-		err = migrate.GoTo(mctx, int(currentVersion), toVersionInt)
+		err = migrate.GoTo(mctx, currentVersion, file.Version(toVersionInt))
 		if err != nil {
 			logErr(err).Fatalf("Failed to migrate to vefrsion %d", toVersionInt)
 		}


### PR DESCRIPTION
When using the goto cli, it uses the +n/-n migrate call. Because it uses an offset with the diff between two timestamps this can cause all migrations to call up/down respectively with a large offset value causing all up/down scripts to be run. Added a goto method that will determine the direction and then stop when the timestamp exceeds (or equals in the case of an upgrade) the desired migration point.