### PR TITLE
Fix: do not log error for redo, when is nil

### DIFF
--- a/commands/migrate_commands.go
+++ b/commands/migrate_commands.go
@@ -116,7 +116,9 @@ var redoCommand = cli.Command{
 		migrate, mctx, cancel := newMigrateWithCtx(ctx.GlobalString("url"), ctx.GlobalString("path"))
 		defer cancel()
 		err := migrate.Redo(mctx)
-		logErr(err).Fatal("Failed to redo last migration")
+		if err != nil {
+			logErr(err).Fatal("Failed to redo last migration")
+		}
 		logCurrentVersion(mctx, migrate)
 		return nil
 	},


### PR DESCRIPTION
This PR will prevent logging error with error status code when command finished with success.

Before logs looked like this:
```
INFO[0000] Redoing last migration
INFO[0000] Applying down migration for version 20191025125334 (some_migration_name)
INFO[0001] Applying up migration for version 20191025125334 (some_migration_name)
FATA[0003] Failed to redo last migration                 error="<nil>"
```

Now it will be:
```
INFO[0000] Redoing last migration
INFO[0000] Applying down migration for version 20191025125334 (some_migration_name)
INFO[0001] Applying up migration for version 20191025125334 (some_migration_name)
INFO[0003] Current version: 20191025125334
```