### PR TITLE
Support go 1.18

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -11,4 +11,5 @@ require (
 	github.com/golang/snappy v0.0.1 // indirect
 	github.com/sirupsen/logrus v1.4.2
 	github.com/urfave/cli/v2 v2.1.1
+	golang.org/x/sys v0.0.0-20220811171246-fbc7d0a398ab // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -64,6 +64,8 @@ golang.org/x/net v0.0.0-20190603091049-60506f45cf65/go.mod h1:HSz+uSET+XFnRR8LxR
 golang.org/x/sys v0.0.0-20190215142949-d0b11bdaac8a/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20190422165155-953cdadca894 h1:Cz4ceDQGXuKRnVBDTS23GTn/pU5OE2C0WrNTOYK1Uuc=
 golang.org/x/sys v0.0.0-20190422165155-953cdadca894/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20220811171246-fbc7d0a398ab h1:2QkjZIsXupsJbJIdSjjUOgWK3aEtzyuh2mPt3l/CkeU=
+golang.org/x/sys v0.0.0-20220811171246-fbc7d0a398ab/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.3.2/go.mod h1:bEr9sfX3Q8Zfm5fL9x+3itogRgK3+ptLWKqgva+5dAk=
 golang.org/x/tools v0.0.0-20180917221912-90fa682c2a6e/go.mod h1:n7NCudcB/nEzxVGmLbDWY5pfWTLqBcC2KZ6jyYvM4mQ=


### PR DESCRIPTION
Hey all!

When trying to install journey with go 1.18 on `darwin/arm64` it fails as follows:
```
❯ go version
go version go1.18.3 darwin/arm64

❯ go install github.com/db-journey/journey/v2@latest
# golang.org/x/sys/unix
../../go/pkg/mod/golang.org/x/sys@v0.0.0-20190422165155-953cdadca894/unix/zsyscall_darwin_arm64.go:28:3: //go:linkname must refer to declared function or variable
../../go/pkg/mod/golang.org/x/sys@v0.0.0-20190422165155-953cdadca894/unix/zsyscall_darwin_arm64.go:43:3: //go:linkname must refer to declared function or variable
../../go/pkg/mod/golang.org/x/sys@v0.0.0-20190422165155-953cdadca894/unix/zsyscall_darwin_arm64.go:59:3: //go:linkname must refer to declared function or variable
../../go/pkg/mod/golang.org/x/sys@v0.0.0-20190422165155-953cdadca894/unix/zsyscall_darwin_arm64.go:75:3: //go:linkname must refer to declared function or variable
../../go/pkg/mod/golang.org/x/sys@v0.0.0-20190422165155-953cdadca894/unix/zsyscall_darwin_arm64.go:90:3: //go:linkname must refer to declared function or variable
../../go/pkg/mod/golang.org/x/sys@v0.0.0-20190422165155-953cdadca894/unix/zsyscall_darwin_arm64.go:105:3: //go:linkname must refer to declared function or variable
../../go/pkg/mod/golang.org/x/sys@v0.0.0-20190422165155-953cdadca894/unix/zsyscall_darwin_arm64.go:121:3: //go:linkname must refer to declared function or variable
../../go/pkg/mod/golang.org/x/sys@v0.0.0-20190422165155-953cdadca894/unix/zsyscall_darwin_arm64.go:136:3: //go:linkname must refer to declared function or variable
../../go/pkg/mod/golang.org/x/sys@v0.0.0-20190422165155-953cdadca894/unix/zsyscall_darwin_arm64.go:151:3: //go:linkname must refer to declared function or variable
../../go/pkg/mod/golang.org/x/sys@v0.0.0-20190422165155-953cdadca894/unix/zsyscall_darwin_arm64.go:166:3: //go:linkname must refer to declared function or variable
../../go/pkg/mod/golang.org/x/sys@v0.0.0-20190422165155-953cdadca894/unix/zsyscall_darwin_arm64.go:166:3: too many errors
```
As described in a similar issue [here](https://github.com/golang/go/issues/51091#issuecomment-1033334340), I just bumped the version of `golang.org/x/sys` to fix this.